### PR TITLE
Making the package installable by pip in one line

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,16 +136,10 @@ Tag2Text is an efficient and controllable vision-language model with tagging gui
 
 ### **Setting Up** ###
 
-1. Install the dependencies::
-
-<pre/>pip install -r requirements.txt</pre>
-
-2. Download RAM pretrained checkpoints.
-
-3. (Optional) To use RAM and Tag2Text in other projects, better to install recognize-anything as a package:
+1. Install recognize-anything as a package:
 
 ```bash
-pip install -e .
+pip install git+https://github.com/xinyu1205/recognize-anything.git
 ```
 
 Then the RAM and Tag2Text model can be imported in other projects:

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ torch
 torchvision
 Pillow
 scipy
-git+https://github.com/openai/CLIP.git
+clip @ git+https://github.com/openai/CLIP.git

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,11 +1,12 @@
 [metadata]
-name = recognize-anything
+name = ram
 version = 0.0.1
 description = Recognize Anything Model and Tag2Text Model
 
 [options]
 packages = find:
 include_package_data = True
+install_requires = file: requirements.txt
 
 [options.packages.find]
 exclude =


### PR DESCRIPTION
Hi,

I have made a few changes so that your package can be easily installed in one single pip line:
```bash
pip install git+https://github.com/xinyu1205/recognize-anything.git
```
This way it'll grab all the packages it requires and also avoid the cloning and local install :)

Cheers,

Guillaume