### PR TITLE
Update transformers version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 timm==0.4.12
-transformers==4.25.0
+transformers==4.25.1
 fairscale==0.4.4
 pycocoevalcap
 torch


### PR DESCRIPTION
This PR updates the transformers version from `transformers==4.25.0` to `4.25.1`. The former version was yanked from PyPI.

Closes https://github.com/xinyu1205/recognize-anything/issues/97