### PR TITLE
Return scores with tags + mask of Original Tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -559,10 +559,11 @@ python -m torch.distributed.run --nproc_per_node=8 finetune.py \
 If you find our work to be useful for your research, please consider citing.
 
 ```
-@article{huang2023inject,
-  title={Inject Semantic Concepts into Image Tagging for Open-Set Recognition},
+@article{huang2023open,
+  title={Open-Set Image Tagging with Multi-Grained Text Supervision},
   author={Huang, Xinyu and Huang, Yi-Jie and Zhang, Youcai and Tian, Weiwei and Feng, Rui and Zhang, Yuejie and Xie, Yanchun and Li, Yaqian and Zhang, Lei},
-  journal={arXiv preprint arXiv:2310.15200},
+  journal={arXiv e-prints},
+  pages={arXiv--2310},
   year={2023}
 }
 

--- a/README.md
+++ b/README.md
@@ -17,9 +17,11 @@ This project aims to develop a series of open-source and strong fundamental imag
   RAM is an image tagging model, which can **recognize any common category with high accuracy**.
 
 
-- **Tag2Text**  [[Paper](https://arxiv.org/abs/2303.05657)] [[Demo](https://huggingface.co/spaces/xinyu1205/recognize-anything)]<br>
+- **Tag2Text (ICLR 2024)**  [[Paper](https://arxiv.org/abs/2303.05657)] [[Demo](https://huggingface.co/spaces/xinyu1205/recognize-anything)]<br>
 
   Tag2Text is a vision-language model guided by tagging, which can **support caption and tagging simultaneously**.
+  
+  Tag2Text is accepted at **ICLR 2024!** See you in Vienna!
 
 
 

--- a/README.md
+++ b/README.md
@@ -559,13 +559,11 @@ python -m torch.distributed.run --nproc_per_node=8 finetune.py \
 If you find our work to be useful for your research, please consider citing.
 
 ```
-@misc{huang2023openset,
-      title={Open-Set Image Tagging with Multi-Grained Text Supervision}, 
-      author={Xinyu Huang and Yi-Jie Huang and Youcai Zhang and Weiwei Tian and Rui Feng and Yuejie Zhang and Yanchun Xie and Yaqian Li and Lei Zhang},
-      year={2023},
-      eprint={2310.15200},
-      archivePrefix={arXiv},
-      primaryClass={cs.CV}
+@article{huang2023inject,
+  title={Inject Semantic Concepts into Image Tagging for Open-Set Recognition},
+  author={Huang, Xinyu and Huang, Yi-Jie and Zhang, Youcai and Tian, Weiwei and Feng, Rui and Zhang, Yuejie and Xie, Yanchun and Li, Yaqian and Zhang, Lei},
+  journal={arXiv preprint arXiv:2310.15200},
+  year={2023}
 }
 
 @article{zhang2023recognize,

--- a/ram/inference.py
+++ b/ram/inference.py
@@ -33,9 +33,9 @@ def inference_tag2text(image, model, input_tag="None"):
 def inference_ram(image, model):
 
     with torch.no_grad():
-        tags, tags_chinese = model.generate_tag(image)
+        tags = model.generate_tag(image)
 
-    return tags[0],tags_chinese[0]
+    return tags
 
 
 def inference_ram_openset(image, model):

--- a/ram/models/ram.py
+++ b/ram/models/ram.py
@@ -324,19 +324,9 @@ class RAM(nn.Module):
             torch.tensor(1.0).to(image.device),
             torch.zeros(self.num_class).to(image.device))
 
-        tag = targets.cpu().numpy()
-        tag[:,self.delete_tag_index] = 0
-        tag_output = []
-        tag_output_chinese = []
-        for b in range(bs):
-            index = np.argwhere(tag[b] == 1)
-            token = self.tag_list[index].squeeze(axis=1)
-            tag_output.append(' | '.join(token))
-            token_chinese = self.tag_list_chinese[index].squeeze(axis=1)
-            tag_output_chinese.append(' | '.join(token_chinese))
-
-
-        return tag_output, tag_output_chinese
+        probs = torch.softmax(logits, dim=-1)
+        result = list(zip(self.tag_list, probs[0].cpu().numpy().tolist()))
+        return result
 
     def generate_tag_openset(self,
                  image,


### PR DESCRIPTION
Modify the generate_tag function to return the scores along with the tag predictions.

Also return a mask of tags that would'd have been returned by RAM originally.