### PR TITLE
Enable huggingface transformers cache disabling

### DIFF
--- a/ram/models/ram.py
+++ b/ram/models/ram.py
@@ -21,6 +21,7 @@ class RAM(nn.Module):
     def __init__(self,
                  med_config=f'{CONFIG_PATH}/configs/med_config.json',
                  image_size=384,
+                 text_encoder_type='bert-base-uncased',
                  vit='base',
                  vit_grad_ckpt=False,
                  vit_ckpt_layer=0,
@@ -122,7 +123,7 @@ class RAM(nn.Module):
                 vit, image_size, vit_grad_ckpt, vit_ckpt_layer)
 
         # create tokenzier
-        self.tokenizer = init_tokenizer()
+        self.tokenizer = init_tokenizer(text_encoder_type)
 
         # Tag2Text employ encoder-decoder architecture for image-tag-text generation: image-tag interaction encoder and image-tag-text decoder
         # create image-tag interaction encoder

--- a/ram/models/ram_plus.py
+++ b/ram/models/ram_plus.py
@@ -22,6 +22,7 @@ class RAM_plus(nn.Module):
     def __init__(self,
                  med_config=f'{CONFIG_PATH}/configs/med_config.json',
                  image_size=384,
+                 text_encoder_type='bert-base-uncased',
                  vit='base',
                  vit_grad_ckpt=False,
                  vit_ckpt_layer=0,
@@ -123,7 +124,7 @@ class RAM_plus(nn.Module):
                 vit, image_size, vit_grad_ckpt, vit_ckpt_layer)
 
         # create tokenzier
-        self.tokenizer = init_tokenizer()
+        self.tokenizer = init_tokenizer(text_encoder_type)
 
         self.delete_tag_index = delete_tag_index
 

--- a/ram/models/tag2text.py
+++ b/ram/models/tag2text.py
@@ -21,6 +21,7 @@ class Tag2Text(nn.Module):
     def __init__(self,
                  med_config=f'{CONFIG_PATH}/configs/med_config.json',
                  image_size=384,
+                 text_encoder_type='bert-base-uncased',
                  vit='base',
                  vit_grad_ckpt=False,
                  vit_ckpt_layer=0,
@@ -85,7 +86,7 @@ class Tag2Text(nn.Module):
                 vit, image_size, vit_grad_ckpt, vit_ckpt_layer)
 
         # create tokenzier
-        self.tokenizer = init_tokenizer()
+        self.tokenizer = init_tokenizer(text_encoder_type)
 
         # Tag2Text employ encoder-decoder architecture for image-tag-text generation: image-tag interaction encoder and image-tag-text decoder
         # create image-tag interaction encoder

--- a/ram/models/utils.py
+++ b/ram/models/utils.py
@@ -127,8 +127,8 @@ class GroupWiseLinear(nn.Module):
         return x
 
 
-def init_tokenizer():
-    tokenizer = BertTokenizer.from_pretrained('bert-base-uncased')
+def init_tokenizer(text_encoder_type='bert-base-uncased'):
+    tokenizer = BertTokenizer.from_pretrained(text_encoder_type)
     tokenizer.add_special_tokens({'bos_token': '[DEC]'})
     tokenizer.add_special_tokens({'additional_special_tokens': ['[ENC]']})
     tokenizer.enc_token_id = tokenizer.additional_special_tokens_ids[0]


### PR DESCRIPTION
With the current code, the function init_tokenizer() in model/utils.py, without any parameter, does not allow to disable the user cache usage by the huggingface module "transformers".
To enable that feature, it is possible to give as parameter a path to a folder containing the required files to the BertTokenizer.from_pretrained method instead of just the tokenizer type as it is done in the current code.
This is useful when working offline with the TRANSFORMERS_OFFLINE environment variable set to TRUE.
This PR updates the function init_tokenizer prototype and the models accordingly to enable that.
A 'text_encoder_type' parameter is added to the 3 models, it can be set to a specific directory when creating a model, avoiding access to the user cache.