### PR TITLE
Relax transformers version constrains

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 timm==0.4.12
-transformers>=4.34.1,<5
+transformers>=4.25.1,<5
 fairscale==0.4.4
 pycocoevalcap
 torch

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 timm==0.4.12
-transformers==4.25.1
+transformers>=4.25.1,<4.33
 fairscale==0.4.4
 pycocoevalcap
 torch

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 timm==0.4.12
-transformers>=4.25.1,<4.33
+transformers>=4.34.1,<5
 fairscale==0.4.4
 pycocoevalcap
 torch


### PR DESCRIPTION
Relax transformers version to be more compatible with other libraries when using in the same data pipeline. 
Updated from  `transformers==4.25.1` to `transformers>=4.25.1,<4.33`

Tested in my own pipeline and it seems to work just fine. We could also increase the upper version limit, but I wanted to be cautious as the higher we go away from 4.25.1, the more likely we might encounter breaking changes. Maintainers can make comments on this.