### PR TITLE
Relax transformers dependency version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 timm==0.4.12
-transformers==4.25.1
+transformers>=4.25.1
 fairscale==0.4.4
 pycocoevalcap
 torch


### PR DESCRIPTION
This PR relaxes `transformers` version from `==4.25.1` to `>=4.25.1`.
The `transformers` library is under active development, and fixed version prevents the users from using the latest transformers features.

Resolves:
- https://github.com/xinyu1205/recognize-anything/issues/175
- https://github.com/xinyu1205/recognize-anything/issues/199
