### PR TITLE
Remove incorrect requirements on setup cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -6,7 +6,6 @@ description = Recognize Anything Plus Model, Recognize Anything Model and Tag2Te
 [options]
 packages = find:
 include_package_data = True
-install_requires = file: requirements.txt
 
 [options.packages.find]
 exclude =


### PR DESCRIPTION
When I run `pip install -e .`, I always got following errors. To fix this error, remove incorrect format from setup.cfg. I checked it works without error.

```
#5 14.11 Obtaining file:///recognize-anything
#5 14.11   Preparing metadata (setup.py): started
#5 14.32   Preparing metadata (setup.py): finished with status 'error'
#5 14.33   error: subprocess-exited-with-error
#5 14.33   
#5 14.33   × python setup.py egg_info did not run successfully.
#5 14.33   │ exit code: 1
#5 14.33   ╰─> [41 lines of output]
#5 14.33       Traceback (most recent call last):
#5 14.33         File "/opt/conda/lib/python3.10/site-packages/pkg_resources/_vendor/packaging/requirements.py", line 102, in __init__
#5 14.33           req = REQUIREMENT.parseString(requirement_string)
#5 14.33         File "/opt/conda/lib/python3.10/site-packages/pkg_resources/_vendor/pyparsing.py", line 1654, in parseString
#5 14.33           raise exc
#5 14.33         File "/opt/conda/lib/python3.10/site-packages/pkg_resources/_vendor/pyparsing.py", line 1644, in parseString
#5 14.33           loc, tokens = self._parse( instring, 0 )
#5 14.33         File "/opt/conda/lib/python3.10/site-packages/pkg_resources/_vendor/pyparsing.py", line 1402, in _parseNoCache
#5 14.33           loc,tokens = self.parseImpl( instring, preloc, doActions )
#5 14.33         File "/opt/conda/lib/python3.10/site-packages/pkg_resources/_vendor/pyparsing.py", line 3417, in parseImpl
#5 14.33           loc, exprtokens = e._parse( instring, loc, doActions )
#5 14.33         File "/opt/conda/lib/python3.10/site-packages/pkg_resources/_vendor/pyparsing.py", line 1406, in _parseNoCache
#5 14.33           loc,tokens = self.parseImpl( instring, preloc, doActions )
#5 14.33         File "/opt/conda/lib/python3.10/site-packages/pkg_resources/_vendor/pyparsing.py", line 3205, in parseImpl
#5 14.33           raise ParseException(instring, loc, self.errmsg, self)
#5 14.33       pkg_resources._vendor.pyparsing.ParseException: Expected stringEnd (at char 4), (line:1, col:5)
#5 14.33       
#5 14.33       During handling of the above exception, another exception occurred:
#5 14.33       
#5 14.33       Traceback (most recent call last):
#5 14.33         File "<string>", line 2, in <module>
#5 14.33         File "<pip-setuptools-caller>", line 34, in <module>
#5 14.33         File "/recognize-anything/setup.py", line 2, in <module>
#5 14.33           setuptools.setup()
#5 14.33         File "/opt/conda/lib/python3.10/site-packages/setuptools/__init__.py", line 154, in setup
#5 14.33           _install_setup_requires(attrs)
#5 14.33         File "/opt/conda/lib/python3.10/site-packages/setuptools/__init__.py", line 146, in _install_setup_requires
#5 14.33           dist.parse_config_files(ignore_option_errors=True)
#5 14.33         File "/opt/conda/lib/python3.10/site-packages/setuptools/dist.py", line 807, in parse_config_files
#5 14.33           self._finalize_requires()
#5 14.33         File "/opt/conda/lib/python3.10/site-packages/setuptools/dist.py", line 534, in _finalize_requires
#5 14.33           self._move_install_requirements_markers()
#5 14.33         File "/opt/conda/lib/python3.10/site-packages/setuptools/dist.py", line 573, in _move_install_requirements_markers
#5 14.33           inst_reqs = list(pkg_resources.parse_requirements(spec_inst_reqs))
#5 14.33         File "/opt/conda/lib/python3.10/site-packages/pkg_resources/__init__.py", line 3099, in parse_requirements
#5 14.33           yield Requirement(line)
#5 14.33         File "/opt/conda/lib/python3.10/site-packages/pkg_resources/__init__.py", line 3109, in __init__
#5 14.33           super(Requirement, self).__init__(requirement_string)
#5 14.33         File "/opt/conda/lib/python3.10/site-packages/pkg_resources/_vendor/packaging/requirements.py", line 104, in __init__
#5 14.33           raise InvalidRequirement(
#5 14.33       pkg_resources.extern.packaging.requirements.InvalidRequirement: Parse error at "': requir'": Expected stringEnd
#5 14.33       [end of output]
#5 14.33   
#5 14.33   note: This error originates from a subprocess, and is likely not a problem with pip.
#5 14.33 error: metadata-generation-failed
#5 14.33 
#5 14.33 × Encountered error while generating package metadata.
#5 14.33 ╰─> See above for output.
#5 14.33 
#5 14.33 note: This is an issue with the package mentioned above, not pip.
#5 14.33 hint: See above for details.
```