### PR TITLE
Solve ImportError for function find_pruneable_heads_and_indices

### DIFF
--- a/ram/models/bert.py
+++ b/ram/models/bert.py
@@ -36,12 +36,17 @@ from transformers.modeling_outputs import (
     SequenceClassifierOutput,
     TokenClassifierOutput,
 )
+
 from transformers.modeling_utils import (
     PreTrainedModel,
+)
+
+from transformers.pytorch_utils import (
     apply_chunking_to_forward,
     find_pruneable_heads_and_indices,
     prune_linear_layer,
 )
+
 from transformers.utils import logging
 from transformers.models.bert.configuration_bert import BertConfig
 

--- a/ram/models/bert.py
+++ b/ram/models/bert.py
@@ -41,11 +41,14 @@ from transformers.modeling_utils import (
     PreTrainedModel,
 )
 
-from transformers.pytorch_utils import (
-    apply_chunking_to_forward,
+from transformers.utils import (
     find_pruneable_heads_and_indices,
     prune_linear_layer,
 )
+from transformers.pytorch_utils import (
+    apply_chunking_to_forward,
+)
+
 
 from transformers.utils import logging
 from transformers.models.bert.configuration_bert import BertConfig

--- a/ram/models/bert.py
+++ b/ram/models/bert.py
@@ -40,14 +40,11 @@ from transformers.modeling_outputs import (
 from transformers.modeling_utils import (
     PreTrainedModel,
 )
-
-from transformers.utils import (
-    find_pruneable_heads_and_indices,
-    prune_linear_layer,
-)
 from transformers.pytorch_utils import (
     apply_chunking_to_forward,
+        prune_linear_layer,
 )
+
 
 
 from transformers.utils import logging
@@ -55,6 +52,45 @@ from transformers.models.bert.configuration_bert import BertConfig
 
 
 logger = logging.get_logger(__name__)
+
+def find_pruneable_heads_and_indices(
+    heads: list[int],
+    n_heads: int,
+    head_size: int,
+    already_pruned_heads: set[int],
+) -> tuple[set[int], torch.LongTensor]:
+    """
+    Finds the heads and the flattened indices to keep, taking already-pruned heads
+    into account.
+
+    Parameters
+    ----------
+    heads : list[int]
+        Head indices requested for pruning.
+    n_heads : int
+        Total number of attention heads before this pruning step.
+    head_size : int
+        Size of each attention head.
+    already_pruned_heads : set[int]
+        Heads that were pruned in earlier steps.
+
+    Returns
+    -------
+    tuple[set[int], torch.LongTensor]
+        (new_heads_to_prune, flattened_indices_to_keep)
+    """
+    mask = torch.ones(n_heads, head_size, dtype=torch.bool)
+
+    heads = set(heads) - already_pruned_heads
+
+    for head in heads:
+        # Shift the head index left by however many smaller heads
+        # were already removed earlier.
+        shifted_head = head - sum(1 for h in already_pruned_heads if h < head)
+        mask[shifted_head] = False
+
+    index = torch.arange(n_heads * head_size)[mask.view(-1)].long()
+    return heads, index
 
 
 class BertEmbeddings_nopos(nn.Module):

--- a/ram/models/utils.py
+++ b/ram/models/utils.py
@@ -131,7 +131,7 @@ def init_tokenizer(text_encoder_type='bert-base-uncased'):
     tokenizer = BertTokenizer.from_pretrained(text_encoder_type)
     tokenizer.add_special_tokens({'bos_token': '[DEC]'})
     tokenizer.add_special_tokens({'additional_special_tokens': ['[ENC]']})
-    tokenizer.enc_token_id = tokenizer.additional_special_tokens_ids[0]
+    # tokenizer.enc_token_id = tokenizer.additional_special_tokens_ids[0]
     return tokenizer
 
 


### PR DESCRIPTION
function "find_pruneable_heads_and_indices" has been removed from the current v5 public internals, according to https://discuss.huggingface.co/t/importerror-for-function-find-pruneable-heads-and-indices/174317 .

Implemented the "find_pruneable_heads_and_indices" inside models/bert.py 

Please review.